### PR TITLE
Add go-checks reusable workflow

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,29 @@
+# Use like:
+
+# name: Backport Assistant
+# on:
+#   pull_request_target:
+#     types:
+#       - closed
+#       - labeled
+# permissions: write-all
+# jobs:
+#   backport:
+#     uses: hashicorp/vault-workflows-common/.github/workflows/backport.yaml
+
+name: Run backport assistant
+
+on:
+  workflow_call: {}
+
+jobs:
+  backport:
+    runs-on: ubuntu-latest
+    container: hashicorpdev/backport-assistant:0.2.2
+    steps:
+      - name: Run Backport Assistant for release branches
+        run: backport-assistant backport
+        env:
+          BACKPORT_LABEL_REGEXP: "backport/vault-(?P<target>\\d+\\.\\d+\\.\\w+)"
+          BACKPORT_TARGET_TEMPLATE: "release/vault-{{.target}}"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go-checks.yaml
+++ b/.github/workflows/go-checks.yaml
@@ -1,0 +1,89 @@
+# use like:
+
+# name: Go checks
+# on:
+#   push:
+# jobs:
+#   go-checks:
+#     uses: hashicorp/vault-workflows-common/.github/workflows/go-checks.yaml
+
+
+name: Run go checks
+
+env:
+  GO_DEFAULT_VERSION: '1.20.1'
+  GOFUMPT_DEFAULT_VERSION: 'v1.15.2'
+
+on:
+  workflow_call:
+    inputs:
+      dir:
+        description: Directory to run checks in
+        type: string
+        required: false
+        default: "$PWD"
+      go_version:
+        description: Version of Go to use.
+        type: string
+        required: false
+        default: '1.20.1'
+      gofumpt_version:
+        description: 'Version of the plugin to cut a release for with *NO* "v", e.g., 1.2.3'
+        required: false
+        type: string
+        default: 'v0.3.1'
+      gofumpt_exclude_patterns:
+        description: List of grep patterns (comma-separated) to exclude for gofumpt check
+        required: false
+        type: string
+        default: "vendor,pb.go"
+
+jobs:
+  gomod:
+    name: Check that go.mod and go.sum are tidy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Setup Go
+        uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613 # v3.4.0
+        with:
+          go-version: ${{ inputs.go_version }}
+      - name: Check go.mod and go.sum tidiness
+        run: |
+          go mod tidy
+          if [ ! -z "$(git status --porcelain go.mod go.sum)" ]; then
+            echo "Need to run 'go mod tidy'";
+            exit 1;
+          fi
+  gofumpt:
+    name: Check that code matches gofumpt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Setup Go
+        uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613 # v3.4.0
+        with:
+          go-version: ${{ inputs.go_version }}
+      - name: Run gofumpt
+        run: |
+          echo "==> Install gofumpt ${{ inputs.gofumpt_version }}"
+          go install mvdan.cc/gofumpt@${{ inputs.gofumpt_version }}
+          echo "==> Checking that code complies with gofmt requirements..."
+
+          files=$(find . -name '*.go')
+          patterns='${{ inputs.gofumpt_exclude_patterns }}'
+          OLDIFS=$IFS
+          IFS=","
+          for pattern in $patterns; do
+            files=$(echo $files | grep -v $pattern);
+          done
+          IFS=$OLDIFS
+          gofmt_files=$(gofmt -l $files)
+          if [[ -n ${gofmt_files} ]]; then
+              echo 'gofmt needs running on the following files:'
+              echo "${gofmt_files}"
+              echo "You can use the command: \`gofumpt -w\` to reformat them."
+              exit 1
+          fi

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -1,3 +1,25 @@
+# use like:
+
+# name: JIRA Sync
+# on:
+#   issues:
+#     types: [opened, closed, deleted, reopened]
+#   pull_request_target:
+#     types: [opened, closed, reopened]
+#   issue_comment: # Also triggers when commenting on a PR from the conversation view
+#     types: [created]
+# jobs:
+#   sync:
+#     uses: hashicorp/vault-workflows-common/.github/workflows/jira.yaml
+#     # assuming you use Vault to get secrets
+#     # if you use GitHub secrets, use secrets.XYZ instead of steps.secrets.outputs.XYZ
+#     secrets:
+#       JIRA_SYNC_BASE_URL: ${{ steps.secrets.outputs.JIRA_SYNC_BASE_URL }}
+#       JIRA_SYNC_USER_EMAIL: ${{ steps.secrets.outputs.JIRA_SYNC_USER_EMAIL }}
+#       JIRA_SYNC_API_TOKEN: ${{ steps.secrets.outputs.JIRA_SYNC_API_TOKEN }}
+#     with:
+#       teams-array: '["ecosystem", "foundations"]'
+
 on:
   workflow_call:
     inputs:
@@ -13,7 +35,7 @@ on:
       JIRA_SYNC_API_TOKEN:
         required: true
 
-name: Jira Sync
+name: JIRA Sync
 
 jobs:
   sync:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-/ @hashicorp/vault-ecosystem
+@hashicorp/vault-ecosystem

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-@hashicorp/vault-ecosystem
+* @hashicorp/vault-ecosystem

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/workflows/jira.yaml @hashicorp/vault-ecosystem
+/ @hashicorp/vault-ecosystem


### PR DESCRIPTION
The gofumpt and go.mod tidy checks were tested on a repository.

I also added some usage instructions for the JIRA sync, and did a simple test, though I was not able to test the whole action completely yet.

For backports, I wrote something that might work, but when I tried to test it, it always failed with:

```
2023/03/01 23:18:39 backport-assistant error: error while applying
environment option in New: error while authenticating with GitHub:
GET https://api.github.com/user: 403 Resource not accessible by integration []
```

I don't think we use the backport flow that often for plugins, so it may not get used. (And even so, it is only a single step, so it isn't terrible to copy-paste, if we can figure out the permissions issue).

I did not do add a reusable check for the changelog, as I'm not sure exactly what it would do. Should it check that the changelog is updated in ever PR?

I also did not add a reusable check for security-scanner, as that is available as a action step with minimal configuration.