### PR TITLE
Add actionlint workflow and use go version file for tests

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,0 +1,21 @@
+# Use like:
+
+# name: Lint GitHub Actions Workflows
+# jobs:
+#   actionlint:
+#     # using `main` as the ref will keep your workflow up-to-date
+#     uses: hashicorp/vault-workflows-common/.github/workflows/actionlint.yaml@main
+
+name: Lint GitHub Actions Workflows
+on:
+  push:
+    paths:
+    - '.github/workflows/**'
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: "Check workflow files"
+        uses: docker://docker.mirror.hashicorp.services/rhysd/actionlint:latest

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -9,7 +9,8 @@
 # permissions: write-all
 # jobs:
 #   backport:
-#     uses: hashicorp/vault-workflows-common/.github/workflows/backport.yaml@{ref}
+#     # using `main` as the ref will keep your workflow up-to-date
+#     uses: hashicorp/vault-workflows-common/.github/workflows/backport.yaml@main
 
 name: Run backport assistant
 

--- a/.github/workflows/go-checks.yaml
+++ b/.github/workflows/go-checks.yaml
@@ -5,7 +5,8 @@
 #   push:
 # jobs:
 #   go-checks:
-#     uses: hashicorp/vault-workflows-common/.github/workflows/go-checks.yaml@{ref}
+#     # using `main` as the ref will keep your workflow up-to-date
+#     uses: hashicorp/vault-workflows-common/.github/workflows/go-checks.yaml@main
 
 
 name: Run go checks

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -10,7 +10,8 @@
 #     types: [created]
 # jobs:
 #   sync:
-#     uses: hashicorp/vault-workflows-common/.github/workflows/jira.yaml@{ref}
+#     # using `main` as the ref will keep your workflow up-to-date
+#     uses: hashicorp/vault-workflows-common/.github/workflows/jira.yaml@main
 #     # assuming you use Vault to get secrets
 #     # if you use GitHub secrets, use secrets.XYZ instead of steps.secrets.outputs.XYZ
 #     secrets:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,7 +5,8 @@
 #   push:
 # jobs:
 #   run-tests:
-#     uses: hashicorp/vault-workflows-common/.github/workflows/tests.yaml@{ref}
+#     # using `main` as the ref will keep your workflow up-to-date
+#     uses: hashicorp/vault-workflows-common/.github/workflows/tests.yaml@main
 
 
 name: Tests
@@ -17,14 +18,28 @@ permissions:
   contents: read
 
 jobs:
+  get-go-version:
+    name: "Determine Go toolchain version"
+    runs-on: ubuntu-latest
+    outputs:
+      go-version: ${{ steps.get-go-version.outputs.go-version }}
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Determine Go version
+        id: get-go-version
+        run: |
+          echo "Building with Go $(cat .go-version)"
+          echo "go-version=$(cat .go-version)" >> "$GITHUB_OUTPUT"
   run-tests:
     name: "Run Tests"
     runs-on: ubuntu-latest
+    needs:
+      - get-go-version
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version-file: './go.mod'
+          go-version: ${{ needs.get-go-version.outputs.go-version }}
           cache: true
       - name: Run Tests
         run: make test


### PR DESCRIPTION
- add [actionlint](https://github.com/hashicorp/GHA-migration/blob/main/docs/configure_linting.md) reusable workflow to lint GH actions files
- make the Tests action use a `.go-version` file instead of the go.mod's go version to ensure reproducibility
- update the usage examples to use `main` as the ref so consumers don't have to do manual updates