### PR TITLE
Added option to not open tickets for dependabot

### DIFF
--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -28,6 +28,11 @@ on:
         required: true
         type: string
         description: 'JSON formatted array of teams to create issues with, e.g. ["ecosystem", "foundations"]. Must use double quotes for each element.'
+      ignore_dependabot:
+        required: false
+        type: boolean
+        default: true
+        description: 'Whether to create Jira tickets for pull-requests opened by dependabot or not'
     secrets:
       JIRA_SYNC_BASE_URL:
         required: true
@@ -58,8 +63,11 @@ jobs:
         else
           echo "type=ISS" >> $GITHUB_OUTPUT
         fi
+        if [[ "${{ github.triggering_actor }}" == "dependabot[bot]" ]] && [[ "${{ inputs.ignore_dependabot }}" == true ]]; then
+          echo "short_circuit=true" >> $GITHUB_OUTPUT
+        fi
     - name: Create ticket
-      if: github.event.action == 'opened' || github.event.action == 'created'
+      if: steps.preprocess.outputs.short_circuit != true && (github.event.action == 'opened' || github.event.action == 'created')
       uses: tomhjp/gh-action-jira-create@3ed1789cad3521292e591a7cfa703215ec1348bf # https://github.com/tomhjp/gh-action-jira-create@v0.2.1
       with:
         project: VAULT


### PR DESCRIPTION
Applications team previously discussed that Dependabot is overly noisy and one of the action item was to stop creating Jira tickets for every pull-requests.

I added a flag so it can be turned back on if a particular team or project wants to.