### PR TITLE
fix jira if syntax

### DIFF
--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -59,7 +59,7 @@ jobs:
           echo "type=ISS" >> $GITHUB_OUTPUT
         fi
     - name: Create ticket
-      if: !(github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'dependencies')) && (github.event.action == 'opened' || github.event.action == 'created')
+      if: (!(github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'dependencies'))) && (github.event.action == 'opened' || github.event.action == 'created')
       uses: tomhjp/gh-action-jira-create@3ed1789cad3521292e591a7cfa703215ec1348bf # https://github.com/tomhjp/gh-action-jira-create@v0.2.1
       with:
         project: VAULT

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -59,7 +59,7 @@ jobs:
           echo "type=ISS" >> $GITHUB_OUTPUT
         fi
     - name: Create ticket
-      if: (!(github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'dependencies'))) && (github.event.action == 'opened' || github.event.action == 'created')
+      if: github.event.action == 'opened' && !(github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'dependencies'))
       uses: tomhjp/gh-action-jira-create@3ed1789cad3521292e591a7cfa703215ec1348bf # https://github.com/tomhjp/gh-action-jira-create@v0.2.1
       with:
         project: VAULT


### PR DESCRIPTION
I am not sure if this is correct but I don't get an error from actionlint with this change.

Actionlint was reporting:

```
.github/workflows/jira.yaml:62:0: could not parse as YAML: yaml: line 62: did not find expected alphabetic or numeric character [yaml-syntax]
   |
62 |       if: !(github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'dependencies')) && (github.event.action == 'opened' || github.event.action == 'created')
   |
```

See https://github.com/hashicorp/vault-plugin-database-couchbase/actions/runs/4472797426