### PR TITLE
set the token at the job level

### DIFF
--- a/.github/workflows/bulk-dependency-updates.yaml
+++ b/.github/workflows/bulk-dependency-updates.yaml
@@ -11,7 +11,6 @@
 #     # using `main` as the ref will keep your workflow up-to-date
 #     uses: hashicorp/vault-workflows-common/.github/workflows/bulk-dependency-updates.yaml@main
 #     secrets:
-#       REPO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 #       VAULT_ECO_GITHUB_TOKEN: ${{ secrets.VAULT_ECO_GITHUB_TOKEN }}
 #     with:
 #       # either hashicorp/vault-ecosystem-applications or hashicorp/vault-ecosystem-foundations
@@ -37,9 +36,6 @@ on:
         type: string
         description: 'The workflow run ID as per the github.run_id context property.'
     secrets:
-      REPO_GITHUB_TOKEN:
-        required: true
-        description: 'The default GITHUB_TOKEN for your workflow.'
       VAULT_ECO_GITHUB_TOKEN:
         required: true
         description: 'Should be different than the default GITHUB_TOKEN so that this workflow will trigger checks on the resulting PR.'
@@ -52,13 +48,14 @@ jobs:
       # This branch will receive updates each time the workflow runs
       # It doesn't matter if it's deleted when merged, it'll be re-created
       BRANCH_NAME: auto-dependency-upgrades
+      GITHUB_TOKEN: ${{ secrets.VAULT_ECO_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version-file: .go-version
           cache: true
-          # Use a separate token to automatically execute checks on the resulting PR
+          # We don't use the default token so that checks are executed on the resulting PR
           # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
           token: ${{ secrets.VAULT_ECO_GITHUB_TOKEN }}
 
@@ -86,7 +83,6 @@ jobs:
       - name: Open pull request if needed
         if: steps.changes.outputs.count > 0
         env:
-          GH_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
           REVIEWER_TEAM: ${{ inputs.reviewer-team }}
           REPO: ${{ inputs.repository }}
           RUN_ID: ${{ inputs.run-id }}


### PR DESCRIPTION
We should only need one token. Also, Commits were being [made by the github-actions user](https://github.com/hashicorp/vault-plugin-database-snowflake/pull/42/commits/d25f1ffc0b8a2cc0eb9b7637e6ce6882aa685383) but this resulted in the [CLA not-signed block](https://github.com/hashicorp/vault-plugin-database-snowflake/pull/42). So we set the token at the job level.