### PR TITLE
jira sync: use teams label mapping

### DIFF
--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -58,6 +58,21 @@ jobs:
         else
           echo "type=ISS" >> $GITHUB_OUTPUT
         fi
+
+        echo "==> Determining team labels"
+        teams_field='[]'
+        for team in $(echo "${{ inputs.teams-array }}" | jq -r '.[]'); do
+          if [[ "$team" == "applications" ]] || [[ "$team" == "foundations" ]]; then
+            t="${team}-eco"
+            # append team label to array
+            teams_field="$(echo "$teams_field" | jq --arg tt "$t" '. |= . + [$tt]')"
+          else
+            echo "==> Error: unsupported teams-array input: ${{ inputs.teams-array }}"
+            exit 1
+          fi
+        done
+
+        echo "teams_array=$teams_field" >> "$GITHUB_OUTPUT"
     - name: Create ticket
       if: github.event.action == 'opened' && !(github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'dependencies'))
       uses: tomhjp/gh-action-jira-create@3ed1789cad3521292e591a7cfa703215ec1348bf # https://github.com/tomhjp/gh-action-jira-create@v0.2.1
@@ -68,7 +83,7 @@ jobs:
         description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created from GitHub Action for ${{ github.event.issue.html_url || github.event.pull_request.html_url }} from ${{ github.actor }}_"
         # customfield_10089 is Issue Link custom field
         # customfield_10091 is team custom field
-        extraFields: '{"fixVersions": [{"name": "TBD"}], "customfield_10091": ${{ inputs.teams-array }}, "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}"}'
+        extraFields: '{"fixVersions": [{"name": "TBD"}], "customfield_10091": ${{ steps.preprocess.outputs.teams_array }}, "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}"}'
     - name: Search
       if: github.event.action != 'opened'
       id: search


### PR DESCRIPTION
Jira requires "-eco" labels now so update this common workflow to set the correct label(s) instead of updating all the repo inputs. This has some limitations and is just a simple fix. Don't mix `["appliations-eco", "foundations"]` for example.