### PR TITLE
bulk updgrades: use correct user for authenticated commit & push steps

### DIFF
--- a/.github/workflows/bulk-dependency-updates.yaml
+++ b/.github/workflows/bulk-dependency-updates.yaml
@@ -74,8 +74,8 @@ jobs:
         # Only push if changes exist
         if: steps.changes.outputs.count > 0
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name hc-github-team-secure-vault-ecosystem
+          git config user.email hc-github-team-secure-vault-ecosystem@users.noreply.github.com
           git add .
           git commit -m "Automated dependency upgrades"
           git push -f origin ${{ github.ref_name }}:"$BRANCH_NAME"


### PR DESCRIPTION
PR's are blocked due to the default github user not having signed the CLA. This was due to setting that user in the git config. This PR should fix that.