### PR TITLE
bulk upgrades: set token for checkout to execute checks

### DIFF
--- a/.github/workflows/bulk-dependency-updates.yaml
+++ b/.github/workflows/bulk-dependency-updates.yaml
@@ -51,13 +51,14 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.VAULT_ECO_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          # We don't use the default token so that checks are executed on the resulting PR
+          # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+          token: ${{ secrets.VAULT_ECO_GITHUB_TOKEN }}
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version-file: .go-version
           cache: true
-          # We don't use the default token so that checks are executed on the resulting PR
-          # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
-          token: ${{ secrets.VAULT_ECO_GITHUB_TOKEN }}
 
       - name: Upgrade Go dependencies
         run: |


### PR DESCRIPTION
We need to set the token for actions/checkout so that checks are executed on the resulting PR. I had it set on the wrong step.

I will get this working eventually...