### PR TITLE
jira sync: step output parse error

### DIFF
--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -76,7 +76,7 @@ jobs:
         fi
 
         echo "==> Using labels: $teams_field"
-        echo "'teams_array="${teams_field}"'" >> "$GITHUB_OUTPUT"
+        echo "teams_array=${teams_field}" >> "$GITHUB_OUTPUT"
 
     - name: Create ticket
       if: github.event.action == 'opened' && !(github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'dependencies'))


### PR DESCRIPTION
See the error here: https://github.com/hashicorp/vault-plugin-database-snowflake/actions/runs/4746063918/jobs/8429223968?pr=48 in "Create ticket". The github output wasn't getting set.

I tested this locally with `act` that `echo '${{ steps.preprocess.outputs.teams_array }}'` will output the value we expect.

3rd time is a charm?