### PR TITLE
Add copyright headers check

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -21,4 +21,4 @@ jobs:
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: "Check workflow files"
-        uses: docker://docker.mirror.hashicorp.services/rhysd/actionlint:latest
+        uses: docker://docker.mirror.hashicorp.services/rhysd/actionlint:3f24bf9d72ca67af6f9f8f3cc63b0e24621b57bf421cecfc452c3312e32b68cc # v1.6.24

--- a/.github/workflows/copyright-headers.yaml
+++ b/.github/workflows/copyright-headers.yaml
@@ -1,0 +1,22 @@
+# Use like:
+
+# name: Lint
+# on:
+#   push:
+# jobs:
+#   copyright:
+#     # using `main` as the ref will keep your workflow up-to-date
+#     uses: hashicorp/vault-workflows-common/.github/workflows/copyright-headers.yaml@main
+
+name: Check copyright headers
+
+on:
+  workflow_call: {}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: hashicorp/setup-copywrite@867a1a2a064a0626db322392806428f7dc59cb3e # v1.1.2
+      - run: copywrite headers --plan

--- a/.github/workflows/go-checks.yaml
+++ b/.github/workflows/go-checks.yaml
@@ -29,7 +29,7 @@ on:
         required: false
         default: '1.20.1'
       gofumpt_version:
-        description: 'Version of the plugin to cut a release for with *NO* "v", e.g., 1.2.3'
+        description: 'Version of gofumpt to use'
         required: false
         type: string
         default: 'v0.3.1'


### PR DESCRIPTION
Simple reminder check to help reduce the number of follow-up PRs we need for copyright headers.

See https://github.com/hashicorp/vault-csi-provider/pull/208 for an example usage and testing before and after fixing the headers.

Also pins the actionlint docker image we use, and fixes a comment.