### PR TITLE
Ensure setup-go consistently uses go-version-file input

### DIFF
--- a/.github/workflows/bulk-dependency-updates.yaml
+++ b/.github/workflows/bulk-dependency-updates.yaml
@@ -58,7 +58,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version-file: .go-version
-          cache: true
 
       - name: Upgrade Go dependencies
         run: |

--- a/.github/workflows/go-checks.yaml
+++ b/.github/workflows/go-checks.yaml
@@ -11,10 +11,6 @@
 
 name: Run go checks
 
-env:
-  GO_DEFAULT_VERSION: '1.20.1'
-  GOFUMPT_DEFAULT_VERSION: 'v1.15.2'
-
 on:
   workflow_call:
     inputs:
@@ -23,16 +19,11 @@ on:
         type: string
         required: false
         default: "$PWD"
-      go_version:
-        description: Version of Go to use.
-        type: string
-        required: false
-        default: '1.20.1'
       gofumpt_version:
         description: 'Version of the plugin to cut a release for with *NO* "v", e.g., 1.2.3'
         required: false
         type: string
-        default: 'v0.3.1'
+        default: 'v0.5.0'
       gofumpt_exclude_patterns:
         description: List of grep patterns (comma-separated) to exclude for gofumpt check
         required: false
@@ -49,7 +40,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
-          go-version: ${{ inputs.go_version }}
+          go-version-file: .go-version
       - name: Check go.mod and go.sum tidiness
         run: |
           go mod tidy
@@ -66,7 +57,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
-          go-version: ${{ inputs.go_version }}
+          go-version-file: .go-version
       - name: Run gofumpt
         run: |
           echo "==> Install gofumpt ${{ inputs.gofumpt_version }}"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version-file: .go-version
-          cache: true
       - name: Run Tests
         run: make test
 


### PR DESCRIPTION
* Consistently use `go-version-file` for all `setup-go` usage. We don't currently provide `go_version` as an input for any existing usages, so I deleted that input option too: https://github.com/search?q=org%3Ahashicorp+hashicorp%2Fvault-workflows-common%2F.github%2Fworkflows%2Fgo-checks.yaml&type=code
* `cache` defaults to true from v4.0.0: https://github.com/actions/setup-go/releases/tag/v4.0.0
* Also update gofumpt to the latest version.