### PR TITLE
Add filter for dependabot when creating PRs

### DIFF
--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -79,7 +79,7 @@ jobs:
         echo "teams_array=${teams_field}" >> "$GITHUB_OUTPUT"
 
     - name: Create ticket
-      if: github.event.action == 'opened' && !(github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'dependencies'))
+      if: github.event.action == 'opened' && !(github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'dependencies')) && (github.actor != 'dependabot[bot]')
       uses: tomhjp/gh-action-jira-create@3ed1789cad3521292e591a7cfa703215ec1348bf # v0.2.1
       with:
         project: VAULT


### PR DESCRIPTION
The label check works when you set the label as you create the pull request.

Dependabot however uses a 2-step process where the PR is created then the `dependencies` label is added. Thus the shared workflow still creates Bupm jiras for dependabot PRs. Checking for the actor should filter out dependency update PRs as expected as we transition out of dependabot and into to the bulk update workflow.