### PR TITLE
Update actionlint.yaml to use latest

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -21,4 +21,4 @@ jobs:
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: "Check workflow files"
-        uses: docker://docker.mirror.hashicorp.services/rhysd/actionlint:3f24bf9d72ca67af6f9f8f3cc63b0e24621b57bf421cecfc452c3312e32b68cc # v1.6.24
+        uses: docker://docker.mirror.hashicorp.services/rhysd/actionlint:latest


### PR DESCRIPTION
actionlint runs are failing. See: https://github.com/hashicorp/vault-plugin-secrets-alicloud/actions/runs/4862741913/jobs/8669514349?pr=84

I think we should be using `latest` as per https://github.com/hashicorp/GHA-migration/blob/main/docs/configure_linting.md