### PR TITLE
Add dispatch to vault workflow to create a vault-side PR for build cross-checks

### DIFF
--- a/.github/workflows/bulk-dependency-updates.yaml
+++ b/.github/workflows/bulk-dependency-updates.yaml
@@ -122,7 +122,7 @@ jobs:
             --title "Automated dependency upgrades - dispatch variant" \
             --reviewer "$reviewers" \
             --label "dependencies" \
-            --body "Full log: https://github.com/$REPO/actions/runs/$RUN_ID
+            --body "Full log: https://github.com/hashicorp/$REPO/actions/runs/$RUN_ID
 
             $(./go-mod-changelog.py)
             "

--- a/.github/workflows/bulk-dependency-updates.yaml
+++ b/.github/workflows/bulk-dependency-updates.yaml
@@ -83,13 +83,9 @@ jobs:
       - name: Dispatch to vault
         if: steps.changes.outputs.count > 0
         run: |
-          curl -L \
-          -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{secrets.VAULT_ECO_GITHUB_TOKEN}}" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/hashicorp/vault/actions/workflows/plugin-update-check.yml/dispatches \
-          -d '{"ref":"main","inputs":{"repo":"${{inputs.repository}}","plugin_branch":"'"${BRANCH_NAME}"'"}}'
+          gh workflow run --repo hashicorp/vault plugin-update-check.yml \
+            -f repo="${{ inputs.repository }}" \
+            -f plugin_branch="$BRANCH_NAME"
 
       - name: Open pull request if needed
         if: steps.changes.outputs.count > 0

--- a/.github/workflows/bulk-dependency-updates.yaml
+++ b/.github/workflows/bulk-dependency-updates.yaml
@@ -47,7 +47,7 @@ jobs:
     env:
       # This branch will receive updates each time the workflow runs
       # It doesn't matter if it's deleted when merged, it'll be re-created
-      BRANCH_NAME: auto-dependency-upgrades-dispatch-variant
+      BRANCH_NAME: auto-dependency-upgrades
       GITHUB_TOKEN: ${{ secrets.VAULT_ECO_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -105,10 +105,9 @@ jobs:
 
           # currently unable to set team as reviewer in GHA
           # see https://github.com/cli/cli/issues/6395
-          # cut the reviewers for now for this test
           reviewers=""
           if [[ "$REVIEWER_TEAM" == "hashicorp/vault-ecosystem-applications" ]]; then
-            reviewers="fairclothjm,kpcraig"
+            reviewers="austingebauer,fairclothjm,vinay-gopalan,maxcoulombe,robmonte,Zlaticanin,kpcraig,raymonstah"
           elif [[ "$REVIEWER_TEAM" == "hashicorp/vault-ecosystem-foundations" ]]; then
             reviewers="swenson,benashz,tvoran,tomhjp,kschoche,thyton"
           else
@@ -119,10 +118,10 @@ jobs:
           if [ -z "$PR" ]; then
             gh pr create \
             --head "$BRANCH_NAME" \
-            --title "Automated dependency upgrades - dispatch variant" \
+            --title "Automated dependency upgrades" \
             --reviewer "$reviewers" \
             --label "dependencies" \
-            --body "Full log: https://github.com/hashicorp/$REPO/actions/runs/$RUN_ID
+            --body "Full log: https://github.com/$REPO/actions/runs/$RUN_ID
 
             $(./go-mod-changelog.py)
             "

--- a/.github/workflows/bulk-dependency-updates.yaml
+++ b/.github/workflows/bulk-dependency-updates.yaml
@@ -71,6 +71,7 @@ jobs:
           echo "count=$(git status --porcelain=v1 2>/dev/null | wc -l)" >> "$GITHUB_OUTPUT"
 
       - name: Commit & push changes
+        id: git
         # Only push if changes exist
         if: steps.changes.outputs.count > 0
         run: |
@@ -78,6 +79,7 @@ jobs:
           git config user.email hc-github-team-secure-vault-ecosystem@users.noreply.github.com
           git add .
           git commit -m "Automated dependency upgrades"
+          echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           git push -f origin ${{ github.ref_name }}:"$BRANCH_NAME"
 
       - name: Open pull request if needed
@@ -92,9 +94,10 @@ jobs:
 
           # currently unable to set team as reviewer in GHA
           # see https://github.com/cli/cli/issues/6395
+          # cut the reviewers for now for this test
           reviewers=""
           if [[ "$REVIEWER_TEAM" == "hashicorp/vault-ecosystem-applications" ]]; then
-            reviewers="austingebauer,fairclothjm,vinay-gopalan,maxcoulombe,robmonte,Zlaticanin,kpcraig,raymonstah"
+            reviewers="fairclothjm,kpcraig"
           elif [[ "$REVIEWER_TEAM" == "hashicorp/vault-ecosystem-foundations" ]]; then
             reviewers="swenson,benashz,tvoran,tomhjp,kschoche,thyton"
           else
@@ -116,3 +119,14 @@ jobs:
             echo "Pull request already exists, won't create a new one."
             exit 1
           fi
+
+      - name: Dispatch to vault
+        if: steps.changes.outputs.count > 0
+        run: |
+          curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{secrets.VAULT_ECO_GITHUB_TOKEN}}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/hashicorp/vault/actions/workflows/plugin-update-check.yml/dispatches \
+          -d '{"ref":"main","inputs":{"sha":"${{steps.git.outputs.sha}}","repo":"${{inputs.repository}}"}}'

--- a/.github/workflows/bulk-dependency-updates.yaml
+++ b/.github/workflows/bulk-dependency-updates.yaml
@@ -91,7 +91,7 @@ jobs:
           -H "Authorization: Bearer ${{secrets.VAULT_ECO_GITHUB_TOKEN}}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/hashicorp/vault/actions/workflows/plugin-update-check.yml/dispatches \
-          -d '{"ref":"main","inputs":{"sha":"${{steps.git.outputs.sha}}","repo":"${{inputs.repository}}"}}'
+          -d '{"ref":"main","inputs":{"sha":"${{steps.git.outputs.sha}}","repo":"${{inputs.repository}}","plugin_branch":"'"${BRANCH_NAME}"'"}}'
 
       - name: Open pull request if needed
         if: steps.changes.outputs.count > 0

--- a/.github/workflows/bulk-dependency-updates.yaml
+++ b/.github/workflows/bulk-dependency-updates.yaml
@@ -67,11 +67,10 @@ jobs:
       - name: Detect changes
         id: changes
         run:
-          # This output boolean tells us if the dependencies have actually changed
+          # This output tells us if the dependencies have actually changed
           echo "count=$(git status --porcelain=v1 2>/dev/null | wc -l)" >> "$GITHUB_OUTPUT"
 
       - name: Commit & push changes
-        id: git
         # Only push if changes exist
         if: steps.changes.outputs.count > 0
         run: |
@@ -79,7 +78,6 @@ jobs:
           git config user.email hc-github-team-secure-vault-ecosystem@users.noreply.github.com
           git add .
           git commit -m "Automated dependency upgrades"
-          echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           git push -f origin ${{ github.ref_name }}:"$BRANCH_NAME"
 
       - name: Dispatch to vault
@@ -91,7 +89,7 @@ jobs:
           -H "Authorization: Bearer ${{secrets.VAULT_ECO_GITHUB_TOKEN}}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/hashicorp/vault/actions/workflows/plugin-update-check.yml/dispatches \
-          -d '{"ref":"main","inputs":{"sha":"${{steps.git.outputs.sha}}","repo":"${{inputs.repository}}","plugin_branch":"'"${BRANCH_NAME}"'"}}'
+          -d '{"ref":"main","inputs":{"repo":"${{inputs.repository}}","plugin_branch":"'"${BRANCH_NAME}"'"}}'
 
       - name: Open pull request if needed
         if: steps.changes.outputs.count > 0

--- a/.github/workflows/bulk-dependency-updates.yaml
+++ b/.github/workflows/bulk-dependency-updates.yaml
@@ -47,7 +47,7 @@ jobs:
     env:
       # This branch will receive updates each time the workflow runs
       # It doesn't matter if it's deleted when merged, it'll be re-created
-      BRANCH_NAME: auto-dependency-upgrades
+      BRANCH_NAME: auto-dependency-upgrades-dispatch-variant
       GITHUB_TOKEN: ${{ secrets.VAULT_ECO_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -108,7 +108,7 @@ jobs:
           if [ -z "$PR" ]; then
             gh pr create \
             --head "$BRANCH_NAME" \
-            --title "Automated dependency upgrades" \
+            --title "Automated dependency upgrades - dispatch variant" \
             --reviewer "$reviewers" \
             --label "dependencies" \
             --body "Full log: https://github.com/$REPO/actions/runs/$RUN_ID

--- a/.github/workflows/bulk-dependency-updates.yaml
+++ b/.github/workflows/bulk-dependency-updates.yaml
@@ -82,6 +82,17 @@ jobs:
           echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           git push -f origin ${{ github.ref_name }}:"$BRANCH_NAME"
 
+      - name: Dispatch to vault
+        if: steps.changes.outputs.count > 0
+        run: |
+          curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{secrets.VAULT_ECO_GITHUB_TOKEN}}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/hashicorp/vault/actions/workflows/plugin-update-check.yml/dispatches \
+          -d '{"ref":"main","inputs":{"sha":"${{steps.git.outputs.sha}}","repo":"${{inputs.repository}}"}}'
+
       - name: Open pull request if needed
         if: steps.changes.outputs.count > 0
         env:
@@ -120,13 +131,3 @@ jobs:
             exit 1
           fi
 
-      - name: Dispatch to vault
-        if: steps.changes.outputs.count > 0
-        run: |
-          curl -L \
-          -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{secrets.VAULT_ECO_GITHUB_TOKEN}}" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/hashicorp/vault/actions/workflows/plugin-update-check.yml/dispatches \
-          -d '{"ref":"main","inputs":{"sha":"${{steps.git.outputs.sha}}","repo":"${{inputs.repository}}"}}'

--- a/.github/workflows/bulk-dependency-updates.yaml
+++ b/.github/workflows/bulk-dependency-updates.yaml
@@ -121,6 +121,5 @@ jobs:
             "
           else
             echo "Pull request already exists, won't create a new one."
-            exit 1
           fi
 

--- a/.github/workflows/dispatch-vault-ci.yaml
+++ b/.github/workflows/dispatch-vault-ci.yaml
@@ -46,5 +46,5 @@ jobs:
     steps:
       - name: Dispatch Vault Plugin Update Check
         run: |
-          echo '{"ref":"main","inputs":{"repo":"${{inputs.repository}}","plugin_branch":"${{inputs.branch}}"}}' | \
+          echo "{\"ref\":\"main\",\"inputs\":{\"repo\":\"${{inputs.repository}}\",\"plugin_branch\":\"${{inputs.branch}}\"}}" | \
             gh workflow run --repo hashicorp/vault plugin-update-check.yml --json

--- a/.github/workflows/dispatch-vault-ci.yaml
+++ b/.github/workflows/dispatch-vault-ci.yaml
@@ -46,11 +46,6 @@ jobs:
     steps:
       - name: Dispatch Vault Plugin Update Check
         run: |
-
           gh workflow run --repo hashicorp/vault plugin-update-check.yml \
             -f repo="${{ inputs.repository }}" \
             -f plugin_branch="${{ inputs.branch }}"
-
-
-          # echo "{\"ref\": \"main\", \"inputs\": {\"repo\": \"${{inputs.repository}}\", \"plugin_branch\": \"${{inputs.branch}}\"}}" | \
-          #   gh workflow run --repo hashicorp/vault plugin-update-check.yml --json

--- a/.github/workflows/dispatch-vault-ci.yaml
+++ b/.github/workflows/dispatch-vault-ci.yaml
@@ -1,0 +1,50 @@
+# Use like:
+
+# name: Dispatch Vault CI On Branch
+# on:
+#   workflow_dispatch:
+# jobs:
+#   dispatch:
+#     # using `main` as the ref will keep your workflow up-to-date
+#     uses: hashicorp/vault-workflows-common/.github/workflows/dispatch-vault-ci.yaml@main
+#     secrets:
+#       VAULT_ECO_GITHUB_TOKEN: ${{ secrets.VAULT_ECO_GITHUB_TOKEN }}
+#     with:
+#       repository: ${{ github.repository }}
+#       branch: my-branch
+
+name: Dispatch Vault CI On Branch
+
+on:
+  workflow_call:
+    inputs:
+      repository:
+        required: true
+        type: string
+        description: 'The owner and repository name as per the github.repository context property.'
+      branch:
+        required: true
+        type: string
+        description: 'The name of the plugin branch'
+    secrets:
+      VAULT_ECO_GITHUB_TOKEN:
+        required: true
+        description: 'Should be different than the default GITHUB_TOKEN so that this workflow will trigger checks on the resulting PR.'
+
+jobs:
+  dispatch:
+    name: Dispatch Vault CI
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.VAULT_ECO_GITHUB_TOKEN }}
+    steps:
+      - name: Dispatch Vault Plugin Update Check
+        run: |
+          curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{secrets.VAULT_ECO_GITHUB_TOKEN}}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/hashicorp/vault/actions/workflows/plugin-update-check.yml/dispatches \
+          -d '{"ref":"main","inputs":{"repo":"${{inputs.repository}}","plugin_branch":"${{inputs.branch}}"}}'
+

--- a/.github/workflows/dispatch-vault-ci.yaml
+++ b/.github/workflows/dispatch-vault-ci.yaml
@@ -46,11 +46,5 @@ jobs:
     steps:
       - name: Dispatch Vault Plugin Update Check
         run: |
-          curl -L \
-          -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{secrets.VAULT_ECO_GITHUB_TOKEN}}" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/hashicorp/vault/actions/workflows/plugin-update-check.yml/dispatches \
-          -d '{"ref":"main","inputs":{"repo":"${{inputs.repository}}","plugin_branch":"${{inputs.branch}}"}}'
-
+          echo '{"ref":"main","inputs":{"repo":"${{inputs.repository}}","plugin_branch":"${{inputs.branch}}"}}' | \
+            gh workflow run --repo hashicorp/vault plugin-update-check.yml --json

--- a/.github/workflows/dispatch-vault-ci.yaml
+++ b/.github/workflows/dispatch-vault-ci.yaml
@@ -46,5 +46,10 @@ jobs:
     steps:
       - name: Dispatch Vault Plugin Update Check
         run: |
-          echo "{\"ref\":\"main\",\"inputs\":{\"repo\":\"${{inputs.repository}}\",\"plugin_branch\":\"${{inputs.branch}}\"}}" | \
+          echo "debug:"
+          echo "{\"ref\": \"main\", \"inputs\": {\"repo\": \"${{inputs.repository}}\", \"plugin_branch\": \"${{inputs.branch}}\"}}"
+          echo
+          echo "{\"ref\": \"main\", \"inputs\": {\"repo\": \"${{inputs.repository}}\", \"plugin_branch\": \"${{inputs.branch}}\"}}" | jq
+
+          echo "{\"ref\": \"main\", \"inputs\": {\"repo\": \"${{inputs.repository}}\", \"plugin_branch\": \"${{inputs.branch}}\"}}" | \
             gh workflow run --repo hashicorp/vault plugin-update-check.yml --json

--- a/.github/workflows/dispatch-vault-ci.yaml
+++ b/.github/workflows/dispatch-vault-ci.yaml
@@ -3,6 +3,12 @@
 # name: Dispatch Vault CI On Branch
 # on:
 #   workflow_dispatch:
+#     inputs:
+#       branch:
+#         required: true
+#         type: string
+#         description: 'The git branch that we want Vault to fetch and run CI against.'
+#
 # jobs:
 #   dispatch:
 #     # using `main` as the ref will keep your workflow up-to-date
@@ -11,7 +17,7 @@
 #       VAULT_ECO_GITHUB_TOKEN: ${{ secrets.VAULT_ECO_GITHUB_TOKEN }}
 #     with:
 #       repository: ${{ github.repository }}
-#       branch: my-branch
+#       branch: $${ inputs.branch }}
 
 name: Dispatch Vault CI On Branch
 

--- a/.github/workflows/dispatch-vault-ci.yaml
+++ b/.github/workflows/dispatch-vault-ci.yaml
@@ -46,10 +46,11 @@ jobs:
     steps:
       - name: Dispatch Vault Plugin Update Check
         run: |
-          echo "debug:"
-          echo "{\"ref\": \"main\", \"inputs\": {\"repo\": \"${{inputs.repository}}\", \"plugin_branch\": \"${{inputs.branch}}\"}}"
-          echo
-          echo "{\"ref\": \"main\", \"inputs\": {\"repo\": \"${{inputs.repository}}\", \"plugin_branch\": \"${{inputs.branch}}\"}}" | jq
 
-          echo "{\"ref\": \"main\", \"inputs\": {\"repo\": \"${{inputs.repository}}\", \"plugin_branch\": \"${{inputs.branch}}\"}}" | \
-            gh workflow run --repo hashicorp/vault plugin-update-check.yml --json
+          gh workflow run --repo hashicorp/vault plugin-update-check.yml \
+            -f repo="${{ inputs.respository }}" \
+            -f plugin_branch="${{ inputs.branch }}"
+
+
+          # echo "{\"ref\": \"main\", \"inputs\": {\"repo\": \"${{inputs.repository}}\", \"plugin_branch\": \"${{inputs.branch}}\"}}" | \
+          #   gh workflow run --repo hashicorp/vault plugin-update-check.yml --json

--- a/.github/workflows/dispatch-vault-ci.yaml
+++ b/.github/workflows/dispatch-vault-ci.yaml
@@ -48,7 +48,7 @@ jobs:
         run: |
 
           gh workflow run --repo hashicorp/vault plugin-update-check.yml \
-            -f repo="${{ inputs.respository }}" \
+            -f repo="${{ inputs.repository }}" \
             -f plugin_branch="${{ inputs.branch }}"
 
 


### PR DESCRIPTION
This PR adds a step to the plugin dependency workflow that calls a workflow added on the vault side, which itself creates a PR (and triggers a CI workflow). That workflow adds a link to the PR created in _this_ workflow, so a reviewer can easily see whether that workflow passed.

This dispatch can be tested by updating the `uses` reference in a plugin workflow to point to the `@add-update-plugin-check-workflow` reference instead of `@main`

We could also think about making this a separate workflow, and piecemeal update plugin workflows to call this one instead of the original, as we feel it is appropriate.