### PR TITLE
jira-sync: don't create issue when branch references jira issue

### DIFF
--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -79,7 +79,9 @@ jobs:
         echo "teams_array=${teams_field}" >> "$GITHUB_OUTPUT"
 
     - name: Create ticket
-      if: github.event.action == 'opened' && !(github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'dependencies')) && (github.actor != 'dependabot[bot]')
+      if: |
+        github.event.action == 'opened' && github.actor != 'dependabot[bot]'
+        && ${{ ! startsWith(github.ref, 'VAULT-' ) }} && ${{ ! startsWith(github.ref, 'vault-' ) }}
       uses: tomhjp/gh-action-jira-create@3ed1789cad3521292e591a7cfa703215ec1348bf # v0.2.1
       with:
         project: VAULT


### PR DESCRIPTION
I removed `!(github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'dependencies'))` since the `if` expression was getting unwieldy and `github.actor != 'dependabot[bot]'` is sufficient for checking the source is dependabot.