### PR TITLE
jira-sync: re-add removed create ticket validation

### DIFF
--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -80,7 +80,9 @@ jobs:
 
     - name: Create ticket
       if: |
-        github.event.action == 'opened' && github.actor != 'dependabot[bot]'
+        github.event.action == 'opened'
+        && !(github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'dependencies'))
+        && (github.actor != 'dependabot[bot]')
         && ${{ ! startsWith(github.ref, 'VAULT-' ) }} && ${{ ! startsWith(github.ref, 'vault-' ) }}
       uses: tomhjp/gh-action-jira-create@3ed1789cad3521292e591a7cfa703215ec1348bf # v0.2.1
       with:


### PR DESCRIPTION
#42 seems to have caused issue comments on GH to create a Jira ticket: https://github.com/hashicorp/terraform-provider-vault/actions/runs/6576373475/job/17865618751

Re-adding back some of the previous checks.