### PR TITLE
Fix jira sync conditional

### DIFF
--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -83,7 +83,7 @@ jobs:
         github.event.action == 'opened'
         && !(github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'dependencies'))
         && (github.actor != 'dependabot[bot]')
-        && ${{ ! startsWith(github.ref, 'VAULT-' ) }} && ${{ ! startsWith(github.ref, 'vault-' ) }}
+        && !startsWith(github.head_ref, 'VAULT-' ) && !startsWith(github.head_ref, 'vault-' )
       uses: tomhjp/gh-action-jira-create@3ed1789cad3521292e591a7cfa703215ec1348bf # v0.2.1
       with:
         project: VAULT


### PR DESCRIPTION
Fixes two issues:
* `${{ }}` syntax in the middle of the expression was causing it to always evaluate to true. I _think_ this is because it meant it was evaluating the condition inside the brackets and then outside evaluating the result as a truth-y string
* Uses `github.head_ref` instead of `github.ref` for the branch check. The [docs](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) don't make it 100% clear (For workflows triggered by `pull_request`, this is the pull request merge branch), but in my testing, `github.ref` referred to the branch being merged to, aka `github.base_ref` except with the `refs/heads/` prefix, and `github.head_ref` is the branch that the changes are coming from.