### PR TITLE
Acctest reusable flow

### DIFF
--- a/.github/workflows/acc-tests.yaml
+++ b/.github/workflows/acc-tests.yaml
@@ -53,7 +53,7 @@ jobs:
               echo $v >> $GITHUB_ENV
           done
           make setup-env
-      - name: Configure Vault server
+      - name: Configure project on Vault server
         run: |
           export VAULT_ADDR=http://127.0.0.1:8200
           export VAULT_TOKEN=root

--- a/.github/workflows/acc-tests.yaml
+++ b/.github/workflows/acc-tests.yaml
@@ -1,0 +1,69 @@
+# Flow based on proposal from: https://docs.google.com/document/d/1Gz0DohBnmH2WaqrQA3JCix_m6ISVyX56nYMDdT5worM/edit?usp=sharing
+
+# use like:
+
+# name: Run Acceptance Tests
+# on: push
+# jobs:
+#   run-acceptance-tests:
+#     uses: hashicorp/vault-workflows-common/.github/workflows/acc-tests.yaml@main
+#     secrets: inherit
+
+name: Run Acceptance Tests
+
+on:
+  workflow_call
+
+jobs:
+  run-acc-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - "hashicorp/vault:1.13"
+          - "hashicorp/vault:1.14"
+          - "hashicorp/vault:1.15"
+          - "hashicorp/vault:latest"
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: './go.mod'
+      - name: Build project
+        run: |
+          make dev
+      - name: Set up Vault server
+        run: |
+          docker run -d --rm --net=host \
+          -e VAULT_DEV_ROOT_TOKEN_ID=root \
+          -e VAULT_LOCAL_CONFIG='{"plugin_directory": "${{ github.workspace }}/bin"}' \
+          -v "${{ github.workspace }}/bin:${{ github.workspace }}/bin" \
+          ${{ matrix.image }} &
+      - name: Set up Vault CLI
+        run: |
+          curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+          sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+          sudo apt install vault
+      - name: Set up test environment
+        run: |
+          for v in $(echo '${{ toJson(secrets) }}' | jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]'); do
+              echo $v >> $GITHUB_ENV
+          done
+          make setup-env
+      - name: Configure Vault server
+        run: |
+          export VAULT_ADDR=http://127.0.0.1:8200
+          export VAULT_TOKEN=root
+          source ./bootstrap/terraform/local_environment_setup.sh
+          make configure PLUGIN_DIR="${{ github.workspace }}/bin"
+      - name: Run acceptance tests
+        run: |
+          source ./bootstrap/terraform/local_environment_setup.sh
+          make testacc
+      - name: Clean test environment
+        if: always()
+        run: |
+          make teardown-env

--- a/.github/workflows/acc-tests.yaml
+++ b/.github/workflows/acc-tests.yaml
@@ -27,9 +27,9 @@ jobs:
           - "hashicorp/vault:latest"
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version-file: './go.mod'
       - name: Build project
@@ -37,7 +37,7 @@ jobs:
           make dev
       - name: Set up Vault server
         run: |
-          docker run -d --rm --net=host \
+          docker run -d --name vault --rm --net=host \
           -e VAULT_DEV_ROOT_TOKEN_ID=root \
           -e VAULT_LOCAL_CONFIG='{"plugin_directory": "${{ github.workspace }}/bin"}' \
           -v "${{ github.workspace }}/bin:${{ github.workspace }}/bin" \
@@ -53,7 +53,7 @@ jobs:
               echo $v >> $GITHUB_ENV
           done
           make setup-env
-      - name: Configure project on Vault server
+      - name: Configure Vault server
         run: |
           export VAULT_ADDR=http://127.0.0.1:8200
           export VAULT_TOKEN=root
@@ -63,6 +63,10 @@ jobs:
         run: |
           source ./bootstrap/terraform/local_environment_setup.sh
           make testacc
+      - name: Capture Vault logs
+        if: always()
+        run: |
+          docker logs vault
       - name: Clean test environment
         if: always()
         run: |


### PR DESCRIPTION
Dug my old hackathon project of having a shared acceptance tests workflow that can be reused across all plugins that adopted the [proposed set of make targets](https://docs.google.com/document/d/1Gz0DohBnmH2WaqrQA3JCix_m6ISVyX56nYMDdT5worM/edit?usp=sharing) to standardize how to bootstrap and test plugins locally.

Here is an [example of converting a project](https://github.com/hashicorp/vault-plugin-database-redis/pull/47) (Redis plugin) to the shared pattern & using this workflow to run acc tests on all pull requests.

This workflow will likely need a lot of improvements over time to be more robust, faster and support different plugin setups but it's a start towards more automation.