### PR TITLE
Thaw iceboxed jira ticket if there is a new comment

### DIFF
--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -93,6 +93,7 @@ jobs:
         # customfield_10089 is Issue Link custom field
         # customfield_10091 is team custom field
         extraFields: '{"fixVersions": [{"name": "TBD"}], "customfield_10091": ${{ steps.preprocess.outputs.teams_array }}, "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}"}'
+
     - name: Search
       if: github.event.action != 'opened'
       id: search
@@ -100,18 +101,39 @@ jobs:
       with:
         # cf[10089] is Issue Link custom field
         jql: 'project = "VAULT" and cf[10089]="${{ github.event.issue.html_url || github.event.pull_request.html_url }}"'
+
+    - name: Fetch ticket status
+      if: steps.search.outputs.issue
+      id: status
+      run: |
+        status_name=$(curl -s \
+        -u ${{ secrets.JIRA_SYNC_USER_EMAIL }}:${{ secrets.JIRA_SYNC_API_TOKEN }} \
+        -H "Content-Type: application/json" \
+        -X GET ${{ secrets.JIRA_SYNC_BASE_URL }}rest/api/3/issue/${{ steps.search.outputs.issue }}?fields=status \
+        | jq -r .fields.status.name)
+        echo "status=${status_name}" >> $GITHUB_OUTPUT
+
     - name: Sync comment
       if: github.event.action == 'created' && steps.search.outputs.issue
       uses: tomhjp/gh-action-jira-comment@6eb6b9ead70221916b6badd118c24535ed220bd9 # v0.2.0
       with:
         issue: ${{ steps.search.outputs.issue }}
         comment: "${{ github.actor }} ${{ github.event.review.state || 'commented' }}:\n\n${{ github.event.comment.body || github.event.review.body }}\n\n${{ github.event.comment.html_url || github.event.review.html_url }}"
+
     - name: Close ticket
       if: (github.event.action == 'closed' || github.event.action == 'deleted') && steps.search.outputs.issue
       uses: atlassian/gajira-transition@38fc9cd61b03d6a53dd35fcccda172fe04b36de3 # v3
       with:
         issue: ${{ steps.search.outputs.issue }}
         transition: Closed
+
+    - name: Thaw ticket
+      if: github.event_name == 'issue_comment' && steps.status.outputs.status == 'Icebox'
+      uses: atlassian/gajira-transition@38fc9cd61b03d6a53dd35fcccda172fe04b36de3 # v3
+      with:
+        issue: ${{ steps.search.outputs.issue }}
+        transition: Pending Triage
+
     - name: Reopen ticket
       if: github.event.action == 'reopened' && steps.search.outputs.issue
       uses: atlassian/gajira-transition@38fc9cd61b03d6a53dd35fcccda172fe04b36de3 # v3


### PR DESCRIPTION
Sometimes there are GitHub issues we do not plan to take on internally but do not want to close. For example:
* The issue is not actionable but has a lot of great context in the discussion that could help others
* The issue is a good idea but not impactful enough to justify the amount of work to take it on internally, but we'd gladly accept a pull request
* The issue needs more info to be actionable but the contributor is MIA
* etc.

These issues pile in our backlogs making it harder for teams to prioritise their work. We'd like to suggest that Jira tickets for unactionable GitHub issues should be iceboxed. We should still comment on the issue to let the contributor know that we do not plan to address the issue ourselves and why to set the correct expectations.

A new step is added to thaw iceboxed tickets if new comments are received so new activity doesn't go unnoticed. Thawed tickets are pending triage so they will be reviewed during the team's next refinement session to determine if the ticket is now actionable or should be re-iceboxed for now.