### PR TITLE
Remove unmaintained atlassian actions that used node16

### DIFF
--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -43,12 +43,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Jira sync
     steps:
-    - name: Login
-      uses: atlassian/gajira-login@45fd029b9f1d6d8926c6f04175aa80c0e42c9026 # v3.0.1
-      env:
-        JIRA_BASE_URL: ${{ secrets.JIRA_SYNC_BASE_URL }}
-        JIRA_USER_EMAIL: ${{ secrets.JIRA_SYNC_USER_EMAIL }}
-        JIRA_API_TOKEN: ${{ secrets.JIRA_SYNC_API_TOKEN }}
     - name: Preprocess
       if: github.event.action == 'opened' || github.event.action == 'created'
       id: preprocess
@@ -85,6 +79,10 @@ jobs:
         && (github.actor != 'dependabot[bot]')
         && !startsWith(github.head_ref, 'VAULT-' ) && !startsWith(github.head_ref, 'vault-' )
       uses: tomhjp/gh-action-jira-create@3ed1789cad3521292e591a7cfa703215ec1348bf # v0.2.1
+      env:
+        JIRA_BASE_URL: ${{ secrets.JIRA_SYNC_BASE_URL }}
+        JIRA_USER_EMAIL: ${{ secrets.JIRA_SYNC_USER_EMAIL }}
+        JIRA_API_TOKEN: ${{ secrets.JIRA_SYNC_API_TOKEN }}
       with:
         project: VAULT
         issuetype: "GH Issue"
@@ -98,6 +96,10 @@ jobs:
       if: github.event.action != 'opened'
       id: search
       uses: tomhjp/gh-action-jira-search@04700b457f317c3e341ce90da5a3ff4ce058f2fa # v0.2.2
+      env:
+        JIRA_BASE_URL: ${{ secrets.JIRA_SYNC_BASE_URL }}
+        JIRA_USER_EMAIL: ${{ secrets.JIRA_SYNC_USER_EMAIL }}
+        JIRA_API_TOKEN: ${{ secrets.JIRA_SYNC_API_TOKEN }}
       with:
         # cf[10089] is Issue Link custom field
         jql: 'project = "VAULT" and cf[10089]="${{ github.event.issue.html_url || github.event.pull_request.html_url }}"'
@@ -116,28 +118,42 @@ jobs:
     - name: Sync comment
       if: github.event.action == 'created' && steps.search.outputs.issue
       uses: tomhjp/gh-action-jira-comment@6eb6b9ead70221916b6badd118c24535ed220bd9 # v0.2.0
+      env:
+        JIRA_BASE_URL: ${{ secrets.JIRA_SYNC_BASE_URL }}
+        JIRA_USER_EMAIL: ${{ secrets.JIRA_SYNC_USER_EMAIL }}
+        JIRA_API_TOKEN: ${{ secrets.JIRA_SYNC_API_TOKEN }}
       with:
         issue: ${{ steps.search.outputs.issue }}
         comment: "${{ github.actor }} ${{ github.event.review.state || 'commented' }}:\n\n${{ github.event.comment.body || github.event.review.body }}\n\n${{ github.event.comment.html_url || github.event.review.html_url }}"
 
-    - name: Close ticket
-      if: (github.event.action == 'closed' || github.event.action == 'deleted') && steps.search.outputs.issue
-      uses: atlassian/gajira-transition@38fc9cd61b03d6a53dd35fcccda172fe04b36de3 # v3
-      with:
-        issue: ${{ steps.search.outputs.issue }}
-        transition: Closed
+    - name: Transitions
+      id: transitions
+      if: steps.search.outputs.issue
+      run: |
+        if [[ ("${{ github.event.action }}" == "closed" || "${{ github.event.action }}" == "deleted") && -n "${{ steps.search.outputs.issue }}" ]]; then
+          echo "Closing ticket"
+          echo "name=Closed" >> $GITHUB_OUTPUT
+        elif [[ "${{ github.event_name }}" == "issue_comment" && "${{ steps.status.outputs.status }}" == "Icebox" ]]; then
+          echo "Thawing ticket"
+          echo "name=Pending Triage" >> $GITHUB_OUTPUT
+        elif [[ "${{ github.event.action }}" == "reopened" && -n "${{ steps.search.outputs.issue }}" ]]; then
+          echo "Reopening ticket"
+          echo "name=Reopen" >> $GITHUB_OUTPUT
+        fi
 
-    - name: Thaw ticket
-      if: github.event_name == 'issue_comment' && steps.status.outputs.status == 'Icebox'
-      uses: atlassian/gajira-transition@38fc9cd61b03d6a53dd35fcccda172fe04b36de3 # v3
-      with:
-        issue: ${{ steps.search.outputs.issue }}
-        transition: Pending Triage
+    # Transition issue API reference: https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-transitions-post
+    - name: Transition ticket
+      if: steps.transitions.outputs.name
+      run: |
+        transitions="$(curl --silent \
+          --url '${{ secrets.JIRA_SYNC_BASE_URL }}rest/api/3/issue/${{ steps.search.outputs.issue }}/transitions' \
+          --user '${{ secrets.JIRA_SYNC_USER_EMAIL }}:${{ secrets.JIRA_SYNC_API_TOKEN }}' \
+          --header 'Accept: application/json')"
+        id="$(echo "${transitions}" | jq -r '.transitions[] | select(.name == "${{ steps.transitions.outputs.name }}") | .id')"
 
-    - name: Reopen ticket
-      if: github.event.action == 'reopened' && steps.search.outputs.issue
-      uses: atlassian/gajira-transition@38fc9cd61b03d6a53dd35fcccda172fe04b36de3 # v3
-      with:
-        issue: ${{ steps.search.outputs.issue }}
-        # transitions issue to 'Pending Triage' status
-        transition: Reopen
+        curl --silent \
+          --url '${{ secrets.JIRA_SYNC_BASE_URL }}rest/api/3/issue/${{ steps.search.outputs.issue }}/transitions' \
+          --user '${{ secrets.JIRA_SYNC_USER_EMAIL }}:${{ secrets.JIRA_SYNC_API_TOKEN }}' \
+          --header 'Accept: application/json' \
+          --header 'Content-Type: application/json' \
+          --data "$(printf '{"transition": {"id": "%s"}}' "${id}")"


### PR DESCRIPTION
https://github.com/atlassian/gajira-login and https://github.com/atlassian/gajira-transition have a notice in their readme that they are now unmaintained, and they use node16 which is getting deprecated shortly.

The gh-action-jira-* actions support providing env vars for credentials directly, so we can eliminate use of the login action by using those env vars.

The transition action is relatively trivial, so I figured we could probably just replace it with some curl commands, following the example of the "Fetch ticket status" step.

Tested the full lifecycle with https://github.com/hashicorp/vault-plugin-vaulteco-testing/issues/19 and https://hashicorp.atlassian.net/browse/VAULT-26706.