### PR TITLE
Restrict dependabot github actions updates to hashicorp org

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,19 @@
+---
 version: 2
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-    labels: ["dependencies"]
+      interval: "monthly"
+    groups:
+      github-actions-breaking:
+        update-types:
+          - major
+      github-actions-backward-compatible:
+        update-types:
+          - minor
+          - patch
+    # only update internal github actions, external github actions are handled by https://github.com/hashicorp/security-tsccr/tree/main/automation
+    allow:
+      - dependency-name: "hashicorp/*"


### PR DESCRIPTION
Related:

* https://github.com/hashicorp/vault-workflows-common/pull/68
* https://github.com/hashicorp/security-tsccr/pull/1050