### PR TITLE
remove kv plugin from team override

### DIFF
--- a/repo-teams.txt
+++ b/repo-teams.txt
@@ -20,7 +20,6 @@ vault-plugin-secrets-azure               vault-eco
 vault-plugin-secrets-gcp                 vault-eco
 vault-plugin-secrets-gcpkms              vault-eco
 vault-plugin-secrets-kubernetes          vault-eco
-vault-plugin-secrets-kv                  core
 vault-plugin-secrets-mongodbatlas        vault-eco
 vault-plugin-secrets-openldap            vault-eco
 vault-plugin-secrets-terraform           vault-eco


### PR DESCRIPTION
We will let the plugin set its own labels since it requires `foundations` and `storage`. For now our override logic doesn't account for multiple labels.

Related to https://github.com/hashicorp/vault-plugin-secrets-kv/pull/162