### PR TITLE
If $label is empty use the input teams

### DIFF
--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -62,7 +62,7 @@ jobs:
         # append team label to array
         teams_field="[\"$label\"]"
 
-        if [[ -z "$teams_field" ]]; then
+        if [[ -z "$label" ]]; then
           echo "::debug::No mapping found in repo-teams.txt, letting labels pass through"
           teams_field='${{ inputs.teams-array }}'
         fi


### PR DESCRIPTION
Since $teams_field will always be set to at least `[""]`.