### PR TITLE
jira: Set resolution when closing a card

### DIFF
--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -149,9 +149,15 @@ jobs:
           --header "Accept: application/json")"
         id="$(echo "${transitions}" | jq -r '.transitions[] | select(.name == "${{ steps.transitions.outputs.name }}") | .id')"
 
+        payload="$(printf '{"transition": {"id": "%s"}}' "${id}")"
+        # closing a card requires a resolution
+        if [[ "${{ steps.transitions.outputs.name }}" == "Closed" ]]; then
+          payload="$(printf '{"fields": {"resolution": {"name": "Done"}}, "transition": {"id": "%s"}}' "${id}")"
+        fi
+
         curl --show-error --fail --silent \
           --url "${{ secrets.JIRA_SYNC_BASE_URL }}rest/api/3/issue/${{ steps.search.outputs.issue }}/transitions" \
           --user "${{ secrets.JIRA_SYNC_USER_EMAIL }}:${{ secrets.JIRA_SYNC_API_TOKEN }}" \
           --header "Accept: application/json" \
           --header "Content-Type: application/json" \
-          --data "$(printf '{"transition": {"id": "%s"}}' "${id}")"
+          --data "${payload}"


### PR DESCRIPTION
Closing cards was returning a 400 ([example](https://github.com/hashicorp/vault-helm/actions/runs/18230565618/job/51913235627)): 

```json
{
  "errorMessages": [
    "Resolution is required"
  ],
  "errors": {}
}
```

So this is adding a resolution of "Done" when closing a card. Following the api example here: https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-transitions-post